### PR TITLE
[IMP] improve the cashlogy connection and display the config

### DIFF
--- a/extra_addons/pos_automatic_cashdrawer/__init__.py
+++ b/extra_addons/pos_automatic_cashdrawer/__init__.py
@@ -1,2 +1,3 @@
 from . import pos_automatic_cashdrawer
 from . import account_journal
+from . import models

--- a/extra_addons/pos_automatic_cashdrawer/__openerp__.py
+++ b/extra_addons/pos_automatic_cashdrawer/__openerp__.py
@@ -30,6 +30,7 @@
     'license': 'AGPL-3',
     'depends': ['point_of_sale'],
     'data': [
+        'security/res_groups.xml',
         'pos_automatic_cashdrawer_view.xml',
         'account_journal_view.xml',
         'static/src/xml/templates.xml',

--- a/extra_addons/pos_automatic_cashdrawer/models/__init__.py
+++ b/extra_addons/pos_automatic_cashdrawer/models/__init__.py
@@ -1,0 +1,2 @@
+# -*- coding: utf-8 -*-
+from . import pos_config

--- a/extra_addons/pos_automatic_cashdrawer/models/pos_config.py
+++ b/extra_addons/pos_automatic_cashdrawer/models/pos_config.py
@@ -1,0 +1,40 @@
+# -*- coding: utf-8 -*-
+# Copyright (C) 2016-Today: La Louve (<http://www.lalouve.net/>)
+# @author: Mathieu VATEL (http://www.julius.fr/)
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+
+from openerp import fields, models, api
+
+
+class PosConfig(models.Model):
+    _inherit = 'pos.config'
+
+    group_pos_automatic_cashlogy = fields.Many2one(
+        comodel_name='res.groups',
+        compute='_compute_group_pos_automatic_cashlogy',
+        string='Point of Sale - Allow Cashlogy connection',
+        help="This field is there to pass the id of the "
+        "'PoS - Allow Cashlogy connection'"
+        " Group to the Point of Sale Frontend.")
+
+    @api.multi
+    def _compute_group_pos_automatic_cashlogy(self):
+        for config in self:
+            config.group_pos_automatic_cashlogy = \
+                self.env.ref('pos_automatic_cashdrawer.'
+                             'group_pos_automatic_cashlogy')
+
+    group_pos_automatic_cashlogy_config = fields.Many2one(
+        comodel_name='res.groups',
+        compute='_compute_group_pos_automatic_cashlogy_config',
+        string='Point of Sale - Allow Cashlogy Config',
+        help="This field is there to pass the id of the "
+        "'PoS - Allow Cashlogy config'"
+        " Group to the Point of Sale Frontend.")
+
+    @api.multi
+    def _compute_group_pos_automatic_cashlogy_config(self):
+        for config in self:
+            config.group_pos_automatic_cashlogy_config = \
+                self.env.ref('pos_automatic_cashdrawer.'
+                             'group_pos_automatic_cashlogy_config')

--- a/extra_addons/pos_automatic_cashdrawer/security/res_groups.xml
+++ b/extra_addons/pos_automatic_cashdrawer/security/res_groups.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <data noupdate="1">
+
+        <record model="res.groups" id="group_pos_automatic_cashlogy">
+            <field name="name">PoS - Allow Cashlogy connection</field>
+            <field name="category_id" ref="base.module_category_usability"/>
+        </record>
+
+        <record model="res.groups" id="group_pos_automatic_cashlogy_config">
+            <field name="name">PoS - Allow Cashlogy config</field>
+            <field name="category_id" ref="base.module_category_usability"/>
+        </record>
+
+    </data>
+</odoo>

--- a/extra_addons/pos_automatic_cashdrawer/static/src/xml/pos_automatic_cashdrawer.xml
+++ b/extra_addons/pos_automatic_cashdrawer/static/src/xml/pos_automatic_cashdrawer.xml
@@ -8,7 +8,7 @@
         </t>
     </t>-->
 
-    <t t-name="AutoCashdrawerWidget">
+    <!--<t t-name="AutoCashdrawerWidget">
         <div class="oe_status js_auto_cashdrawer">
             <span class='js_msg oe_orange oe_hidden'></span>
             <div class="js_connected oe_icon oe_green">
@@ -24,21 +24,37 @@
                 <i class='fa fa-fw fa-euro'></i>
             </div>
         </div>
+    </t>-->
+
+    <t t-name="AutoCashdrawerInitWidget">
+        <div class="oe_status js_auto_cashdrawer_init">
+            <div class="button automatic-cashdrawer-connection-init">
+                <i class='fa fa-eur'></i>
+            </div>
+        </div>
     </t>
 
-    <t t-extend="PaymentScreenWidget" >
+    <t t-name="AutoCashdrawerConfigWidget">
+        <div class="oe_status js_auto_cashdrawer_config">
+            <div class="button automatic-cashdrawer-display-backoffice">
+                <i class='fa fa-wrench'></i>
+            </div>
+        </div>
+    </t>
+
+    <!--<t t-extend="PaymentScreenWidget" >
         <t t-jquery=".payment-buttons" t-operation="append">
                 <t t-if="widget.is_manager()">
                     <div class="button automatic-cashdrawer-connection-init">
                         <i class="fa fa-wrench"></i> Connect cashdrawer
                     </div>
-                </t>
+                </t>-->
                 <!-- <button class="automatic-cashdrawer-connection-exit">Disconnect cashdrawer</button> -->
-                <t t-if="widget.is_manager()">
+                <!--<t t-if="widget.is_manager()">
                     <div class="button automatic-cashdrawer-display-backoffice">
                         <i class="fa fa-wrench"></i> Display backoffice
                     </div>
                 </t>
         </t>
-    </t>
+    </t>-->
 </templates>


### PR DESCRIPTION
Hello everybody,

I'va added groups to users to be able to display / hide Cashlogy "Init" and "Setting" buttons for cashiers, the same way the current "Rem.", "qty", etc buttons work on the PoS.

So, right now, the cashier can launch his session. Then the manager can log, and the buttons will be displayed. When the manager log out, the buttons will be hidden.