### PR TITLE
[FIX] group name

### DIFF
--- a/louve_addons/coop_membership/security/res_groups.xml
+++ b/louve_addons/coop_membership/security/res_groups.xml
@@ -25,12 +25,12 @@
     </record>
 
     <record model="res.groups" id="subscriptions_can_change_fundraising_category">
-        <field name="name">Can Change Fundraising Category in Wizard</field>
+        <field name="name">Can Change Fundraising Category (in Wizard)</field>
         <field name="category_id" ref="base.module_category_extra" />
     </record>
 
     <record model="res.groups" id="coop_membership_manager">
-        <field name="name">Manage Louve Membership</field>
+        <field name="name">Manage Louve Membership (Full)</field>
         <field name="category_id" ref="base.module_category_extra" />
     </record>
 


### PR DESCRIPTION
due to refactoring, (louve_membership renamed in coop_membership) updating database fails. 
this PR fixes the bug.

I quick merge, because it is a blocking point.

CC : @jweste , @yuntux .
