### PR TITLE
[FIX] set total w/o tax stored in pos order line

### DIFF
--- a/odoo/addons/point_of_sale/i18n/fr.po
+++ b/odoo/addons/point_of_sale/i18n/fr.po
@@ -3603,6 +3603,11 @@ msgid "Subtotal w/o Tax"
 msgstr "Sous-total hors taxes"
 
 #. module: point_of_sale
+#: model:ir.model.fields,field_description:point_of_sale.field_report_pos_order_price_total_vat_excl
+msgid "Total w/o Taxes"
+msgstr "Total HT"
+
+#. module: point_of_sale
 #: model:ir.model.fields,field_description:point_of_sale.field_report_pos_order_price_sub_total
 msgid "Subtotal w/o discount"
 msgstr "Sous-total hors réduction"

--- a/odoo/addons/point_of_sale/point_of_sale.py
+++ b/odoo/addons/point_of_sale/point_of_sale.py
@@ -1482,8 +1482,8 @@ class pos_order_line(osv.osv):
         'tax_ids_after_fiscal_position': fields.function(_get_tax_ids_after_fiscal_position, type='many2many', relation='account.tax', string='Taxes')
     }
 
-    price_subtotal = Fields.Float(compute='_compute_amount_line_all', digits=0, string='Subtotal w/o Tax')
-    price_subtotal_incl = Fields.Float(compute='_compute_amount_line_all', digits=0, string='Subtotal')
+    price_subtotal = Fields.Float(compute='_compute_amount_line_all', digits=0, string='Subtotal w/o Tax', store=True)
+    price_subtotal_incl = Fields.Float(compute='_compute_amount_line_all', digits=0, string='Subtotal', store=True)
 
     @api.depends('price_unit', 'tax_ids', 'qty', 'discount', 'product_id')
     def _compute_amount_line_all(self):

--- a/odoo/addons/point_of_sale/report/pos_order_report.py
+++ b/odoo/addons/point_of_sale/report/pos_order_report.py
@@ -17,10 +17,12 @@ class pos_order_report(osv.osv):
         'state': fields.selection([('draft', 'New'), ('paid', 'Paid'), ('done', 'Posted'), ('invoiced', 'Invoiced'), ('cancel', 'Cancelled')],
                                   'Status'),
         'user_id':fields.many2one('res.users', 'Salesperson', readonly=True),
+        'price_total_vat_excl':fields.float('Total w/o Taxes', readonly=True),
         'price_total':fields.float('Total Price', readonly=True),
         'price_sub_total':fields.float('Subtotal w/o discount', readonly=True),
         'total_discount':fields.float('Total Discount', readonly=True),
         'average_price': fields.float('Average Price', readonly=True,group_operator="avg"),
+        'order_id':fields.many2one('pos.order', 'Order', readonly=True),
         'location_id':fields.many2one('stock.location', 'Location', readonly=True),
         'company_id':fields.many2one('res.company', 'Company', readonly=True),
         'nbr':fields.integer('# of Lines', readonly=True),  # TDE FIXME master: rename into nbr_lines
@@ -44,7 +46,9 @@ class pos_order_report(osv.osv):
                     min(l.id) as id,
                     count(*) as nbr,
                     s.date_order as date,
+                    s.id as order_id,
                     sum(l.qty * u.factor) as product_qty,
+                    sum(l.price_subtotal) as price_total_vat_excl,
                     sum(l.qty * l.price_unit) as price_sub_total,
                     sum((l.qty * l.price_unit) * (100 - l.discount) / 100) as price_total,
                     sum((l.qty * l.price_unit) * (l.discount / 100)) as total_discount,
@@ -72,7 +76,7 @@ class pos_order_report(osv.osv):
                     left join pos_session ps on (s.session_id=ps.id)
                     left join pos_config pc on (ps.config_id=pc.id)
                 group by
-                    s.date_order, s.partner_id,s.state, pt.categ_id,
+                    s.id, s.date_order, s.partner_id,s.state, pt.categ_id,
                     s.user_id,s.location_id,s.company_id,s.sale_journal,s.pricelist_id,s.invoice_id,l.product_id,s.create_date,pt.categ_id,pt.pos_categ_id,p.product_tmpl_id,ps.config_id,pc.stock_location_id
                 having
                     sum(l.qty * u.factor) != 0)""")

--- a/odoo/addons/point_of_sale/report/pos_order_report_view.xml
+++ b/odoo/addons/point_of_sale/report/pos_order_report_view.xml
@@ -9,7 +9,7 @@
                     <field name="product_categ_id" type="row"/>
                     <field name="date" interval="month" type="col"/>
                     <field name="product_qty" type="measure"/>
-                    <field name="price_total" type="measure"/>
+                    <field name="price_total_vat_excl" type="measure"/>
                 </pivot>
             </field>
         </record>
@@ -20,7 +20,7 @@
             <field name="arch" type="xml">
                 <graph string="Point of Sale Analysis">
                     <field name="product_categ_id" type="row"/>
-                    <field name="price_total" type="measure"/>
+                    <field name="price_total_vat_excl" type="measure"/>
                 </graph>
             </field>
         </record>
@@ -41,11 +41,14 @@
                     <field name="partner_id"/>
                     <field name="user_id"/>
                     <field name="product_id"/>
+                    <field name="order_id"/>
                     <field name="product_categ_id"/>
                     <group expand="1" string="Group By">
                         <filter string="Salesperson" name="User" context="{'group_by':'user_id'}"/>
                         <filter string="Product Category" context="{'group_by':'product_categ_id'}"/>
                         <filter string="Product" context="{'group_by':'product_id'}"/>
+                        <filter string="Order" context="{'group_by':'order_id'}"/>
+                        <filter string="Partner" context="{'group_by':'partner_id'}"/>
                         <separator/>
                         <filter string="Order Month" context="{'group_by':'date:month'}" help="Month of order date"/>
                     </group>


### PR DESCRIPTION
Attention patch du noyau Odoo.

[FIX] rend storé des champs sous-total hors taxe et ttc dans pos.order.line
[IMP] permet d'afficher ces champs dans le rapport

Après déployement : 
-u point_of_sale

Attention : à tester avant sur serveur de test. le store du champs prend 10 minute chez moi.