### PR TITLE
[ADD] - S#12718 - Computation of supplier invoice lines

### DIFF
--- a/extra_addons/purchase_discount/__openerp__.py
+++ b/extra_addons/purchase_discount/__openerp__.py
@@ -19,6 +19,7 @@
     "data": [
         "views/purchase_discount_view.xml",
         "views/report_purchaseorder.xml",
+        "views/res_partner_view.xml",
     ],
     "license": 'AGPL-3',
     'installable': True,

--- a/extra_addons/purchase_discount/i18n/fr.po
+++ b/extra_addons/purchase_discount/i18n/fr.po
@@ -42,3 +42,18 @@ msgstr "Ligne de facuration"
 #: model:ir.model,name:purchase_discount.model_purchase_order_line
 msgid "Purchase Order Line"
 msgstr "Ligne de commande d'achat"
+
+#. module: purchase_discount
+#: model:ir.model.fields,field_description:purchase_discount.field_res_partner_discount_computation
+msgid "Discount Computation"
+msgstr "Application des remises"
+
+#. module: purchase_discount
+#: selection:res.partner,discount_computation:0
+msgid "Total"
+msgstr "Total"
+
+#. module: purchase_discount
+#: selection:res.partner,discount_computation:0
+msgid "Unit Price"
+msgstr "Prix Unitaire"

--- a/extra_addons/purchase_discount/models/__init__.py
+++ b/extra_addons/purchase_discount/models/__init__.py
@@ -5,3 +5,4 @@
 # License AGPL-3 - See http://www.gnu.org/licenses/agpl-3.0.html
 from . import purchase_order
 from . import account_invoice_line
+from . import res_partner

--- a/extra_addons/purchase_discount/models/account_invoice_line.py
+++ b/extra_addons/purchase_discount/models/account_invoice_line.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 # © 2016 ACSONE SA/NV (<http://acsone.eu>)
 # License AGPL-3 - See http://www.gnu.org/licenses/agpl-3.0.html
-from openerp import models
+from openerp import api, models
 
 
 class AccountInvoiceLine(models.Model):
@@ -19,3 +19,37 @@ class AccountInvoiceLine(models.Model):
             account_invoice_line.discount =\
                 account_invoice_line.purchase_line_id.discount
         return account_invoice_line
+
+    @api.one
+    @api.depends('price_unit', 'discount', 'invoice_line_tax_ids', 'quantity',
+                 'product_id', 'invoice_id.partner_id',
+                 'invoice_id.currency_id', 'invoice_id.company_id')
+    def _compute_price(self):
+        currency = self.invoice_id and self.invoice_id.currency_id or None
+        price = self.price_unit * (1 - (self.discount or 0.0) / 100.0)
+
+        # Rounding the price based on the partner discount computation
+        # for supplier invoice or supplier refund
+        if self.invoice_id.type in ['in_invoice', 'in_refund'] and \
+                self.invoice_id.partner_id.discount_computation == \
+                'unit_price':
+            price = currency.round(price)
+
+        taxes = False
+        if self.invoice_line_tax_ids:
+            taxes = self.invoice_line_tax_ids.compute_all(
+                price, currency, self.quantity,
+                product=self.product_id,
+                partner=self.invoice_id.partner_id)
+
+        self.price_subtotal = price_subtotal_signed =\
+            taxes['total_excluded'] if taxes else\
+            self.quantity * price
+        if self.invoice_id.currency_id and self.invoice_id.currency_id !=\
+                self.invoice_id.company_id.currency_id:
+            price_subtotal_signed = self.invoice_id.currency_id.compute(
+                price_subtotal_signed,
+                self.invoice_id.company_id.currency_id)
+        sign = self.invoice_id.type in ['in_refund', 'out_refund'] and -1\
+            or 1
+        self.price_subtotal_signed = price_subtotal_signed * sign

--- a/extra_addons/purchase_discount/models/res_partner.py
+++ b/extra_addons/purchase_discount/models/res_partner.py
@@ -1,0 +1,11 @@
+# -*- coding: utf-8 -*-
+
+from openerp import fields, models
+
+
+class ResPartner(models.Model):
+    _inherit = "res.partner"
+
+    discount_computation = fields.Selection(
+        selection=[('total', 'Total'), ('unit_price', 'Unit Price')],
+        string="Discount Computation")

--- a/extra_addons/purchase_discount/views/res_partner_view.xml
+++ b/extra_addons/purchase_discount/views/res_partner_view.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <record id="res_partner_form_inherit" model="ir.ui.view">
+        <field name="name">res.partner.form.inherit</field>
+        <field name="model">res.partner</field>
+        <field name="inherit_id" ref="base.view_partner_form"/>
+        <field name="arch" type="xml">
+            <field name="debit" position="after">
+                <field name="discount_computation" attrs="{'required': [('supplier', '=', True)]}"/>
+            </field>
+        </field>
+    </record>
+</odoo>

--- a/louve_addons/purchase_package_qty/__openerp__.py
+++ b/louve_addons/purchase_package_qty/__openerp__.py
@@ -60,7 +60,7 @@ Copyright, Author and Licence :
     'depends': [
         'base',
         'product',
-        'purchase',
+        'purchase_discount',
     ],
     'data': [
         'views/product_supplierinfo_view.xml',


### PR DESCRIPTION
Support Ticket [S#12718 - Computation of supplier invoice lines](https://tms.trobz.com/web#id=12718&view_type=form&model=tms.support.ticket)

**Commit 1: [FIX] - S#12718 - Discount on Purchase Order Line makes no affect on computation**
This commit is to fix the issue of discount on purchase order: Changing discount makes no affect on the computation of the Total value on Purchase Order

**Commit 2: [IMP] - S#12718 - Improve the function _compute_price on purchase package qty for inheritance**
This commit is for the improvement of function `_compute_price` which is necessary for the implementation of the Commit 3 (Prevent Technical Block)

**Commit 3: [ADD] - S#12718 - Computation of supplier invoice lines**
The main implementation of this ticket