### PR TITLE
[FIX] - S#12683 - [Bug] Supplier invoice edition: Unable to open the tax line form in Supplier Invoice

### DIFF
--- a/louve_addons/purchase_package_qty/model/account_invoice.py
+++ b/louve_addons/purchase_package_qty/model/account_invoice.py
@@ -68,6 +68,7 @@ class AccountInvoice(models.Model):
                         'out_invoice', 'in_invoice') and
                     (tax['account_id'] or line.account_id.id) or
                     (tax['refund_account_id'] or line.account_id.id),
+                    'base': tax['base'],
                 }
 
                 # If the taxes generate moves on the same financial account as
@@ -87,5 +88,6 @@ class AccountInvoice(models.Model):
                 if key not in tax_grouped:
                     tax_grouped[key] = val
                 else:
+                    tax_grouped[key]['base'] += val['base']
                     tax_grouped[key]['amount'] += val['amount']
         return tax_grouped


### PR DESCRIPTION
Support Ticket: [S#12683 - [Bug] Supplier invoice edition](https://tms.trobz.com/web?db=tms80#id=12683&view_type=form&model=tms.support.ticket)

This PR is for fixing the error message when opening a tax line form in Supplier Invoice

> File "/opt/openerp/openerp-lalouve-staging/addons/lalouve-production/odoo/openerp/api.py", line 248, in wrapper
>     return new_api(self, *args, **kwargs)
>   File "/opt/openerp/openerp-lalouve-staging/addons/lalouve-production/odoo/openerp/models.py", line 3254, in read
>     values[name] = field.convert_to_read(record[name], use_name_get)
>   File "/opt/openerp/openerp-lalouve-staging/addons/lalouve-production/odoo/openerp/models.py", line 5769, in __getitem__
>     return self._fields[key].__get__(self, type(self))
>   File "/opt/openerp/openerp-lalouve-staging/addons/lalouve-production/odoo/openerp/fields.py", line 831, in __get__
>     self.determine_value(record)
>   File "/opt/openerp/openerp-lalouve-staging/addons/lalouve-production/odoo/openerp/fields.py", line 940, in determine_value
>     self.compute_value(recs)
>   File "/opt/openerp/openerp-lalouve-staging/addons/lalouve-production/odoo/openerp/fields.py", line 895, in compute_value
>     self._compute_value(records)
>   File "/opt/openerp/openerp-lalouve-staging/addons/lalouve-production/odoo/openerp/fields.py", line 885, in _compute_value
>     getattr(records, self.compute)()
>   File "/opt/openerp/openerp-lalouve-staging/odoo/addons/account/models/account_invoice.py", line 1320, in _compute_base_amount
>     tax.base = tax_grouped[tax.invoice_id.id][key]['base']
> KeyError: 'base'