### PR TITLE
Popupwaitingreturn

### DIFF
--- a/extra_addons/pos_payment_terminal/__openerp__.py
+++ b/extra_addons/pos_payment_terminal/__openerp__.py
@@ -34,6 +34,6 @@
         'static/src/xml/templates.xml',
         ],
     'demo': ['pos_payment_terminal_demo.xml'],
-#     'qweb': ['static/src/xml/pos_payment_terminal.xml'],
+    'qweb': ['static/src/xml/pos_payment_terminal.xml'],
     'installable': True,
 }

--- a/extra_addons/pos_payment_terminal/static/src/xml/pos_payment_terminal.xml
+++ b/extra_addons/pos_payment_terminal/static/src/xml/pos_payment_terminal.xml
@@ -1,10 +1,28 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <templates id="template" xml:space="preserve">
-    <t t-extend="PaymentScreen-Paymentlines" >
+    <!--<t t-extend="PaymentScreen-Paymentlines" >
         <t t-jquery=".col-name" t-operation="append">
             <t t-if="line.cashregister.journal.payment_mode and widget.pos.config.iface_payment_terminal">
                    <button class="payment-terminal-transaction-start"  t-att-data-cid='line.cid'>Start transaction</button>
             </t>
         </t>
+    </t>-->
+
+    <t t-name="WaitingForTPEReturnPopupWidget">
+        <div class="modal-dialog">
+            <div class="popup popup-wainting-for-tpe-return">
+                <p class="title"><t t-esc=" widget.options.title || '' " /></p>
+                <p class="body"><t t-esc=" widget.options.body || '' " /></p>
+                <div class="footer">
+                    <div class="button confirm">
+                        Ok 
+                    </div>
+                    <!--<div class="button cancel">
+                        Cancel 
+                    </div>-->
+                </div>
+            </div>
+        </div>
     </t>
+
 </templates>


### PR DESCRIPTION
PopUp au lancement de la transaction avec le TPE.
Le popup se ferme automatiquement au retour du TPE, et peut être fermé manuellement s'il y a eu un problème avec la transaction.