### PR TITLE
[FIX] - S#13723 - Incorrect computation of invoice line for non-discount line

### DIFF
--- a/extra_addons/purchase_discount/models/account_invoice_line.py
+++ b/extra_addons/purchase_discount/models/account_invoice_line.py
@@ -31,6 +31,7 @@ class AccountInvoiceLine(models.Model):
         # Rounding the price based on the partner discount computation
         # for supplier invoice or supplier refund
         if self.invoice_id.type in ['in_invoice', 'in_refund'] and \
+            self.discount and \
                 self.invoice_id.partner_id.discount_computation == \
                 'unit_price':
             price = currency.round(price)


### PR DESCRIPTION
**Support Ticket:** [S#13723 - Incorrect totals in Diapar invoice](https://tms.trobz.com/web#id=13723&view_type=form&model=tms.support.ticket&menu_id=277&action=284)