### PR TITLE
[FIX] - S#14200 - Shift Registration Lines are incorrectly updated when leave request is confirmed

### DIFF
--- a/louve_addons/coop_shift/model/shift_leave_wizard.py
+++ b/louve_addons/coop_shift/model/shift_leave_wizard.py
@@ -57,49 +57,67 @@ class ShiftLeaveWizard(models.TransientModel):
     # View Section
     @api.multi
     def button_confirm(self):
-        line_obj = self.env['shift.template.registration.line']
         self.ensure_one()
-        if self.leave_id.state != 'draft':
+
+        leave = self.leave_id
+        if leave.state != 'draft':
             raise ValidationError(_(
                 "You can not confirm a leave in a non draft state."))
 
-        registration_ids = self.shift_template_registration_line_ids.mapped(
-            'registration_id').ids
+        registration_ids = self.shift_template_registration_line_ids\
+            .mapped('registration_id').ids
+        leave_s_date = leave.start_date
+        leave_e_date = leave.stop_date
 
         for line in self.shift_template_registration_line_ids:
             previous_date_end = line.date_end
+            work_s_date = line.date_begin
+            work_e_date = line.date_end
+
             # if same period, delete registration line
-            if line.date_begin == self.leave_id.start_date and\
-                    line.date_end == self.leave_id.stop_date:
+            if work_s_date == leave_s_date and work_e_date == leave_e_date:
                 # We confirm the same leave, previously canceled
                 line.unlink()
-            elif self.leave_id.start_date > line.date_begin:
+            elif leave_s_date >= work_s_date:
                 # Otherwise, Reduce current registration line stop date
-                line.date_end = add_days(self.leave_id.start_date, -1)
-                if self.leave_id.stop_date and \
-                    (not previous_date_end or
-                        previous_date_end > self.leave_id.stop_date):
+                if leave_s_date > work_s_date:
+                    line.date_end = add_days(leave_s_date, -1)
+                else:
+                    line.date_end = leave_e_date
+
+                if leave_e_date and (not previous_date_end or
+                                     previous_date_end > leave_e_date):
                     # Create a new registration line, if leave has stop date
-                    line.copy(default={
-                        'date_begin': add_days(self.leave_id.stop_date, 1),
+                    new_id = line.copy(default={
+                        'date_begin': add_days(leave_e_date, 1),
                         'date_end': previous_date_end,
                     })
-
             else:
-                if self.leave_id.stop_date:
+                if leave_e_date:
                     # Augment current registration line start date
-                    line.date_begin = add_days(self.leave_id.stop_date, -1)
+                    line.date_begin = add_days(leave_e_date, -1)
                 else:
                     line.unlink()
 
+        line_obj = self.env['shift.template.registration.line']
         for registration_id in registration_ids:
-            # Create new registration lines (type 'waiting')
-            line_obj.create({
-                'registration_id': registration_id,
-                'date_begin': self.leave_id.start_date,
-                'date_end': self.leave_id.stop_date,
-                'state': 'waiting',
-                'leave_id': self.leave_id.id,
-            })
+            # Update state of existing registration lines
+            existed_line = line_obj.search([
+                ('registration_id', '=', registration_id),
+                ('date_begin', '=', leave_s_date),
+                ('state', '!=', 'waiting'),
+                ])
+            if existed_line:
+                existed_line.with_context(bypass_leave_change_check=True)\
+                    .write({'state': 'waiting', 'leave_id': leave.id})
+            else:
+                # Create new registration lines (type 'waiting')
+                line_obj.create({
+                    'registration_id': registration_id,
+                    'date_begin': leave_s_date,
+                    'date_end': leave_e_date,
+                    'state': 'waiting',
+                    'leave_id': leave.id,
+                })
 
-        self.leave_id.state = 'done'
+        leave.state = 'done'


### PR DESCRIPTION
**Support Ticket:** [S#14200 - Shift Registration Lines are incorrectly updated when leave request is confirmed](https://tms.trobz.com/web?db=tms80#id=14200&view_type=form&model=tms.support.ticket&menu_id=277&action=284)