### PR TITLE
[FIX] F#31092 - Strong link between account and tax

### DIFF
--- a/intercoop_addons/coop_purchase/__openerp__.py
+++ b/intercoop_addons/coop_purchase/__openerp__.py
@@ -16,11 +16,14 @@
         'purchase_package_qty',
         'purchase_compute_order',
         'coop_product_coefficient',
+        'account_product_fiscal_classification',
     ],
     'data': [
         'views/purchase_view.xml',
         'views/purchase_config_settings_view.xml',
         'views/account_invoice_view.xml',
+        'views/account_product_fiscal_classification_view.xml',
+        'views/product_template_view.xml',
         'views/actions.xml',
         'views/menu.xml'
     ],

--- a/intercoop_addons/coop_purchase/models/__init__.py
+++ b/intercoop_addons/coop_purchase/models/__init__.py
@@ -2,6 +2,8 @@
 
 from . import account_invoice_line
 from . import account_invoice
+from . import account_product_fiscal_classification
 from . import purchase_order_line
 from . import purchase_config_settings
 from . import product_supplierinfo
+from . import product_template

--- a/intercoop_addons/coop_purchase/models/account_product_fiscal_classification.py
+++ b/intercoop_addons/coop_purchase/models/account_product_fiscal_classification.py
@@ -1,0 +1,29 @@
+# -*- coding: utf-8 -*-
+from openerp import models, fields
+
+
+class AccountProductFiscalClassification(models.Model):
+    _inherit = 'account.product.fiscal.classification'
+
+    income_account_id = fields.Many2one(
+        comodel_name='account.account',
+        string='Income Account',
+        required=True
+    )
+    expense_account_id = fields.Many2one(
+        comodel_name='account.account',
+        string='Expense Account',
+        required=True
+    )
+    sale_tax_ids = fields.Many2many(
+        comodel_name='account.tax',
+        relation='fiscal_classification_sale_tax_rel',
+        column1='fiscal_classification_id', column2='tax_id',
+        required=True
+    )
+    purchase_tax_ids = fields.Many2many(
+        comodel_name='account.tax',
+        relation='fiscal_classification_purchase_tax_rel',
+        column1='fiscal_classification_id', column2='tax_id',
+        required=True
+    )

--- a/intercoop_addons/coop_purchase/models/product_template.py
+++ b/intercoop_addons/coop_purchase/models/product_template.py
@@ -1,0 +1,25 @@
+# -*- coding: utf-8 -*-
+from openerp import api, models
+
+
+class ProductTemplate(models.Model):
+    _inherit = 'product.template'
+
+    @api.onchange('categ_id', 'fiscal_classification_id')
+    def _onchange_categ_fiscal_classification_id(self):
+        res = super(
+            ProductTemplate, self)._onchange_categ_fiscal_classification_id()
+        if self.fiscal_classification_id:
+            update_vals = {
+                'property_account_income_id':
+                    self.fiscal_classification_id.income_account_id.id,
+                'property_account_expense_id':
+                    self.fiscal_classification_id.expense_account_id.id,
+            }
+        else:
+            update_vals = {
+                'property_account_income_id': False,
+                'property_account_expense_id': False,
+            }
+        self.update(update_vals)
+        return res

--- a/intercoop_addons/coop_purchase/views/account_product_fiscal_classification_view.xml
+++ b/intercoop_addons/coop_purchase/views/account_product_fiscal_classification_view.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<odoo>
+    <record id="view_account_product_fiscal_classification_form_inherit" model="ir.ui.view">
+        <field name="model">account.product.fiscal.classification</field>
+        <field name="inherit_id" ref="account_product_fiscal_classification.view_account_product_fiscal_classification_form"/>
+        <field name="arch" type="xml">
+            <field name="sale_tax_ids" position="after">
+                 <field name="expense_account_id" />
+                <field name="income_account_id" />
+            </field>
+        </field>
+    </record>
+</odoo>

--- a/intercoop_addons/coop_purchase/views/product_template_view.xml
+++ b/intercoop_addons/coop_purchase/views/product_template_view.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<odoo>
+    <record id="product_template_form_view_inherit" model="ir.ui.view">
+            <field name="name">product.template.form.inherit</field>
+            <field name="model">product.template</field>
+            <field name="inherit_id" ref="account.product_template_form_view"/>
+            <field name="arch" type="xml">
+                <field name="property_account_income_id" position="attributes">
+                    <attribute name="readonly">1</attribute>
+                </field>
+                <field name="property_account_expense_id" position="attributes">
+                    <attribute name="readonly">1</attribute>
+                </field>
+            </field>
+        </record>
+</odoo>


### PR DESCRIPTION
- Update model *account.product.fiscal.classification* by adding new fields: income_account_id and expense_account_id
- Handle onchange *fiscal_classification_id* on product_template form view
- Set readonly for *property_account_income_id* and *property_account_expense_id* of product_template form view
- Set required for *fiscal_classification_id*'s fields: *sale_tax_ids* and *purchase_tax_ids*