### PR TITLE
[FIX] F#34918 - [Workload to Estimate] Hide columns on ABCD points sc…

### DIFF
--- a/intercoop_addons/coop_shift/views/view_shift_counter_event.xml
+++ b/intercoop_addons/coop_shift/views/view_shift_counter_event.xml
@@ -15,10 +15,10 @@
                 <field name="create_uid" readonly="1"/>
                 <field name="shift_id"/>
                 <field name="name"/>
-                <field name="partner_id"/>
-                <field name="type"/>
-                <field name="is_manual"/>
-                <field name="ignored"/>
+                <field name="partner_id" invisible="1"/>
+                <field name="type" invisible="1"/>
+                <field name="is_manual" invisible="1"/>
+                <field name="ignored" invisible="1"/>
                 <field name="is_changed" invisible="1"/>
                 <field name="point_qty" sum="Total Points"/>
                 <field name="notes"/>


### PR DESCRIPTION
…reen

- When we click on the ABCD points smart button on a member’s profile, there are some columns that can be removed on the screen we see.
- Columns to hide : Partner, type, manual, ignored. Columns to keep : Created on, Created by, shift, description, point quantity, notes