### PR TITLE
[FIX] F#34920 - [Workload to Estimate] Shift-leaders not indicated on…

### DIFF
--- a/intercoop_addons/coop_membership/views/view_res_partner.xml
+++ b/intercoop_addons/coop_membership/views/view_res_partner.xml
@@ -822,7 +822,7 @@
                             </group>
                             <group name="squadleader">
                                 <field name="is_squadleader"/>
-                                <field name="template_ids"/>
+                                <field name="template_ids" context="{'tree_view_ref' : 'coop_membership.view_shift_template_tree_leader_one2many'}"/>
                             </group>
                             <group name="button"
                                    groups="coop_shift.group_shift_manager,coop_membership.group_membership_bdm_saisie">

--- a/intercoop_addons/coop_membership/views/view_shift_template.xml
+++ b/intercoop_addons/coop_membership/views/view_shift_template.xml
@@ -14,4 +14,14 @@
         </field>
     </record>
 
+    <record id="view_shift_template_tree_leader_one2many" model="ir.ui.view">
+        <field name="name">shift.template.tree.view.leader.one2many</field>
+        <field name="model">shift.template</field>
+        <field name="arch" type="xml">
+            <tree name="Template Leaders">
+                <field name="user_ids" widget="many2many_tags"/>
+            </tree>
+        </field>
+    </record>
+
 </odoo>

--- a/intercoop_addons/coop_shift/views/res_partner_view.xml
+++ b/intercoop_addons/coop_shift/views/res_partner_view.xml
@@ -23,7 +23,7 @@
                     <page name="shifts" string="Shifts">
                         <group name="squedleader">
                             <field name="is_squadleader"/>
-                            <field name="template_ids"/>
+                            <field name="template_ids"  context="{'tree_view_ref' : 'coop_membership.view_shift_template_tree_leader_one2many'}"/>
                         </group>
                         <group name="button" groups="coop_shift.group_shift_manager">
                             <button name="%(coop_shift.action_add_template_registration)d" type="action" class="oe_highlight" icon="fa-cogs" string="Add Template Registration" id="add_template_registration"/>


### PR DESCRIPTION
… individual member profiles

- Show shift template leaders instead of showing shift.template on res.partner form view