### PR TITLE
[FIX] F#34915 - [Workload to Estimate] Minor improvements for badge p…

### DIFF
--- a/intercoop_addons/coop_membership/models/res_partner.py
+++ b/intercoop_addons/coop_membership/models/res_partner.py
@@ -243,10 +243,12 @@ class ResPartner(models.Model):
     @api.depends('badge_distribution_date', 'badge_print_date')
     def compute_badge_to_distribute(self):
         for record in self:
+            badge_to_distribute = False
             if record.badge_print_date:
                 if not record.badge_distribution_date or\
                         record.badge_distribution_date < record.badge_print_date:
-                    record.badge_to_distribute = True
+                    badge_to_distribute = True
+            record.badge_to_distribute = badge_to_distribute
 
     @api.multi
     def force_customer_button(self):

--- a/intercoop_addons/coop_print_badge/views/badge_to_print_views.xml
+++ b/intercoop_addons/coop_print_badge/views/badge_to_print_views.xml
@@ -24,13 +24,6 @@
 				<xpath expr="//page[@name='coop_data']/group/group[1]/field[@name='is_member']" position="before">
 					<field name="badge_to_print" invisible="1"/>
 				</xpath>
-				<xpath expr="//page[@name='coop_data']/group[1]" position="before">
-					<field name="updated_badges_info" invisible="1" />
-					<group attrs="{'invisible': [('updated_badges_info','=',False)]}">
-						<p class='alert alert-warning'> Des données du badge ont changé, il est nécessaire de réimprimer ce badge. Vous pouvez retrouver tous les badges à réimprimer en utilisant le filtre "Badges à imprimer" sur la vue list. Une fois le badge imprimé, décocher le champ "Badges à imprimer"
-						</p>
-					</group>
-				</xpath>
 			</field>
 		</record>
 	</data>

--- a/intercoop_addons/coop_print_badge/views/view_res_partner.xml
+++ b/intercoop_addons/coop_print_badge/views/view_res_partner.xml
@@ -8,15 +8,6 @@
             <field name="is_member" position="before">
                 <field name="badge_to_print" attrs="{'invisible': [('is_member', '=', False), ('is_associated_people', '=', False)]}" groups="coop_membership.group_membership_access_photo"/>
             </field>
-
-            <xpath expr="//sheet/div[@class='oe_title']" position="after">
-                <field name="updated_badges_info" invisible="1" />
-                <group attrs="{'invisible': [('updated_badges_info','=',False)]}">
-                    <p class='alert alert-warning'> Des données du badge ont changé, il est nécessaire de réimprimer ce badge. Vous pouvez retrouver tous les badges à réimprimer en utilisant le filtre "Badges à imprimer" sur la vue list. Une fois le badge imprimé, décocher le champ "Badges à imprimer"
-                    </p>
-                </group>
-            </xpath>
-
         </field>
     </record>
 


### PR DESCRIPTION
…rocess

- Remove message "Des données du badge ont changé, il est nécessaire de réimprimer ce badge. Vous pouvez retrouver tous les badges à réimprimer en utilisant le filtre "Badges à imprimer" sur la vue list. Une fois le badge imprimé, décocher le champ "Badges à imprimer”"