### PR TITLE
[FIX] pos_payment_terminal communicates currency decimals information to posbox

### DIFF
--- a/extra_addons/pos_payment_terminal/static/src/js/pos_payment_terminal.js
+++ b/extra_addons/pos_payment_terminal/static/src/js/pos_payment_terminal.js
@@ -46,21 +46,22 @@ odoo.define('pos_payment_terminal.pos_payment_terminal', function (require) {
             }
             return false;
         },
-        get_data_send: function(order, line, currency_iso) {
+        get_data_send: function(order, line, currency_iso, currency_decimals) {
             var data = {
                     'amount' : order.get_due(line),
                     'currency_iso' : currency_iso,
+                    'currency_decimals' : currency_decimals,
                     'payment_mode' : line.cashregister.journal.payment_mode,
                     'wait_terminal_answer' : this.wait_terminal_answer(),
                     };
             return data;
         },
 
-        payment_terminal_transaction_start: function(screen, currency_iso){
+        payment_terminal_transaction_start: function(screen, currency_iso, currency_decimals){
             var self = this;
             var order = this.pos.get_order();
             var line = order.selected_paymentline;
-            var data = self.get_data_send(order, line, currency_iso);
+            var data = self.get_data_send(order, line, currency_iso, currency_decimals);
             if (this.wait_terminal_answer()) {
                 screen.$('.delete-button').css('display', 'none');
                 this.message('payment_terminal_transaction_start_with_return', {'payment_info' : JSON.stringify(data)}, { timeout: 240000 }).then(function (answer) {
@@ -109,7 +110,7 @@ odoo.define('pos_payment_terminal.pos_payment_terminal', function (require) {
             var auto = line.get_automatic_payment_terminal();
             $('.back').hide();
             if (auto) {
-                this.pos.proxy.payment_terminal_transaction_start(self, self.pos.currency.name);
+                this.pos.proxy.payment_terminal_transaction_start(self, self.pos.currency.name, self.pos.currency.decimals);
             }
         },
         transaction_error: function() {


### PR DESCRIPTION
This is basically a port of [this pull request](https://github.com/OCA/pos/pull/371/files) to OCA (and [this one](https://github.com/OCA/pos/pull/388)).

pos_payment_terminal is supposed to work with [hw_telium_payment_terminal](https://github.com/OCA/pos/blob/8.0/hw_telium_payment_terminal/), but the telium controller [expects to be told](https://github.com/OCA/pos/blob/8.0/hw_telium_payment_terminal/controllers/main.py#L132) the number of decimals of the currency used for the transaction.

This pull requests make pos_payment_terminal communicate the numbers of decimals to the posbox proxy.

I know that AwesomeFoodCoops largely edited the `hw_telium_payment_terminal` module so it does not need the fix in this pull request to work properly.
However, merging this PR might make future upgrades smoother as it provides compatibility with the upstream.

It also may be a start to fix [this TODO](https://github.com/AwesomeFoodCoops/odoo-production/blob/9.0/extra_addons/hw_telium_payment_terminal/controllers/main.py#L134).

Éloi, from SuperCoop