### PR TITLE
Page planning

### DIFF
--- a/intercoop_addons/coop_memberspace/__openerp__.py
+++ b/intercoop_addons/coop_memberspace/__openerp__.py
@@ -8,7 +8,6 @@
     'name': 'Coop Memberspace',
     'description': """
         Version 0.0.0.2 : ajout de la page planning par Supercoop pour visualiser les prochains services confirmés avec le nombre de places disponibles 
-        ATTENTION : WIP sur la prod de Supercoop, pas encore pushé sur le répertoire github commun !
     """,
     'version': '0.0.0.2',
     'category': 'Custom',

--- a/intercoop_addons/coop_memberspace/__openerp__.py
+++ b/intercoop_addons/coop_memberspace/__openerp__.py
@@ -6,7 +6,11 @@
 
 {
     'name': 'Coop Memberspace',
-    'version': '0.0.0.1',
+    'description': """
+        Version 0.0.0.2 : ajout de la page planning par Supercoop pour visualiser les prochains services confirmés avec le nombre de places disponibles 
+        ATTENTION : WIP sur la prod de Supercoop, pas encore pushé sur le répertoire github commun !
+    """,
+    'version': '0.0.0.2',
     'category': 'Custom',
     'author': 'La Louve',
     'website': 'http://www.lalouve.net',
@@ -45,6 +49,7 @@
         'views/website/statistics.xml',
         'views/website/website_homepage.xml',
         'views/website/website_template.xml',
+        'views/website/planning.xml',
     ],
     'installable': True,
 }

--- a/intercoop_addons/coop_memberspace/controllers/main.py
+++ b/intercoop_addons/coop_memberspace/controllers/main.py
@@ -75,6 +75,20 @@ class Website(openerp.addons.website.controllers.main.Website):
             return http.redirect_with_hash(redirect)
         return r
 
+    @http.route('/planning', type='http', auth='user', website=True)
+    def page_planning(self, **kwargs):
+        upcoming_shifts = request.env['shift.shift'].sudo().search([
+            ('date_begin', '>=', datetime.now().strftime('%Y-%m-%d %H:%M:%S')),
+            ('state', '=', 'confirm'),
+        ], order="date_begin") or []
+        return request.render(
+            'coop_memberspace.planning',
+            {
+                'user': request.env.user,
+                'upcoming_shifts': upcoming_shifts,
+            }
+        )
+
     @http.route('/mywork', type='http', auth='user', website=True)
     def page_mywork(self, **kwargs):
         user = request.env.user

--- a/intercoop_addons/coop_memberspace/data/website_menu.xml
+++ b/intercoop_addons/coop_memberspace/data/website_menu.xml
@@ -65,7 +65,7 @@
             <field name="name">Accueil</field>
         </record>
 
-        <delete model="website.menu" search="[('id','=', ref('website.menu_contactus'))]" />
+        <delete model="website.menu" search="[('id','=', ref('website.contactus'))]" />
 
     </data>
 </openerp>

--- a/intercoop_addons/coop_memberspace/views/website/planning.xml
+++ b/intercoop_addons/coop_memberspace/views/website/planning.xml
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="utf-8"?>
+<openerp><data>
+	<template id="coop_memberspace.planning">
+		<t t-call="website.layout">
+            <t t-set="title">Espace Membre | Planning</t>
+            <div class="container">
+                <div class="row">
+                    <h1>Manque de coopérateurs sur les services à venir</h1>
+                    <p>Page fonctionnelle mais toujours en cours de développement par le cercle informatique, des améliorations (notamment cosmétiques) sont encore prévues :)</p>
+                    <div class="row">
+                        <t t-if="upcoming_shifts">
+                            <t t-set="week_number" t-value="dict(upcoming_shifts[0]._fields['week_number'].selection).get(upcoming_shifts[0].week_number)" />
+                            <t t-set="date" t-value="upcoming_shifts[0].date_without_time" />
+                            <div class="col-md-12"><h3>Semaine <span t-esc="week_number" /></h3></div>
+                            <div class="col-md-12"><h4><span t-esc="date" /></h4></div>
+                        </t>
+                        <t t-if="upcoming_shifts" t-foreach="upcoming_shifts" t-as="shift">
+                            <t t-if="dict(shift._fields['week_number'].selection).get(shift.week_number) != week_number">
+                                <t t-set="week_number" t-value="dict(shift._fields['week_number'].selection).get(shift.week_number)" />
+                                <div class="col-md-12"><h3>Semaine <span t-esc="week_number" /></h3></div>
+                            </t>
+                            <t t-if="shift.date_without_time != date">
+                                <t t-set="date" t-value="shift.date_without_time" />
+                                <div class="col-md-12"><h4><span t-esc="date" /></h4></div>
+                            </t>
+                            <t t-if="shift.seats_available >= shift.seats_reserved" t-set="color" t-value="'red'" />
+                            <t t-if="shift.seats_reserved > shift.seats_available" t-set="color" t-value="'black'" />
+                            <div class="col-md-3" t-attf-style="border: 1px solid {{ color }}; margin: 10px;">
+                                <h5><span t-esc="shift.name" /></h5>
+                                <t t-set="date_begin" t-value="user.get_time_by_user_lang(shift.date_begin, ['%A %d %B %Hh%M', '%HH%M'], lang=user.lang + '.utf8')" />
+                                <t t-set="date_end" t-value="user.get_time_by_user_lang(shift.date_end, ['%A %d %B %Hh%M', '%HH%M'], lang=user.lang + '.utf8')" />
+                                <div><span t-esc="date_begin and date_begin[0] or ''" /> - <span t-esc="date_end and date_end[1] or ''" /></div>
+                                <div><span t-esc="shift.seats_reserved" /> participants attendus</div>
+                                <div t-attf-style="color: {{ color }};"><strong><span t-esc="shift.seats_available" /> places disponibles</strong></div>
+                            </div>
+                        </t>
+                    </div>
+                </div>
+            </div>
+        </t>
+    </template>
+</data></openerp>

--- a/intercoop_addons/coop_memberspace/views/website/planning.xml
+++ b/intercoop_addons/coop_memberspace/views/website/planning.xml
@@ -5,14 +5,14 @@
             <t t-set="title">Espace Membre | Planning</t>
             <div class="container">
                 <div class="row">
-                    <h1>Manque de coopérateurs sur les services à venir</h1>
-                    <p>Page fonctionnelle mais toujours en cours de développement par le cercle informatique, des améliorations (notamment cosmétiques) sont encore prévues :)</p>
+                    <h1>Planning Supercoop</h1>
+                    <p>Manque de coopérateurs sur les services à venir : choisir en priorité les créneaux <span style="color: #ee2c2c;">rouges</span>, puis <span style="color: #ffa500;">oranges</span>, puis <span style="color: #ffd700;">jaunes</span>, puis <span style="color: #ffe4c4;">beiges</span>...</p>
                     <div class="row">
                         <t t-if="upcoming_shifts">
                             <t t-set="week_number" t-value="dict(upcoming_shifts[0]._fields['week_number'].selection).get(upcoming_shifts[0].week_number)" />
                             <t t-set="date" t-value="upcoming_shifts[0].date_without_time" />
                             <div class="col-md-12"><h3>Semaine <span t-esc="week_number" /></h3></div>
-                            <div class="col-md-12"><h4><span t-esc="date" /></h4></div>
+                            <div class="col-md-12"><h4><span t-esc="user.get_time_by_user_lang(upcoming_shifts[0].date_begin, ['%A %d %B %Y'])[0]" /></h4></div>
                         </t>
                         <t t-if="upcoming_shifts" t-foreach="upcoming_shifts" t-as="shift">
                             <t t-if="dict(shift._fields['week_number'].selection).get(shift.week_number) != week_number">
@@ -21,17 +21,32 @@
                             </t>
                             <t t-if="shift.date_without_time != date">
                                 <t t-set="date" t-value="shift.date_without_time" />
-                                <div class="col-md-12"><h4><span t-esc="date" /></h4></div>
+                                <div class="col-md-12"><h4><span t-esc="user.get_time_by_user_lang(shift.date_begin, ['%A %d %B %Y'])[0]" /></h4></div>
                             </t>
-                            <t t-if="shift.seats_available >= shift.seats_reserved" t-set="color" t-value="'red'" />
-                            <t t-if="shift.seats_reserved > shift.seats_available" t-set="color" t-value="'black'" />
-                            <div class="col-md-3" t-attf-style="border: 1px solid {{ color }}; margin: 10px;">
+                            <t t-set="present" t-value="datetime.datetime.now()" />
+                            <t t-set="availability_rate" t-value="float(shift.seats_available) / shift.seats_max" />
+
+                            <t t-set="css_color_style" t-value="''"/>
+                            <t t-if="availability_rate >= 0.25">
+                                <t t-set="css_color_style" t-value="'color: #665b4e; background-color: #ffe4c4'"/>
+                            </t>
+                            <t t-if="availability_rate >= 0.5">
+                                <t t-set="css_color_style" t-value="'color: #665600; background-color: #ffd700'"/>
+                            </t>
+                            <t t-if="availability_rate >= 0.75">
+                                <t t-set="css_color_style" t-value="'color: #664200; background-color: #ffa500;'"/>
+                            </t>
+                            <t t-if="shift.seats_available > 0 and present > (datetime.datetime.strptime(shift.date_begin_tz, '%Y-%m-%d %H:%M:%S') - datetime.timedelta(days=3))">
+                                <t t-set="css_color_style" t-value="'color: #fbd4d4; background-color: #ee2c2c;'"/>
+                            </t>
+
+                            <div t-attf-class="col-md-3" t-attf-style="border: 1px solid; margin: 10px; {{ css_color_style }}">
                                 <h5><span t-esc="shift.name" /></h5>
                                 <t t-set="date_begin" t-value="user.get_time_by_user_lang(shift.date_begin, ['%A %d %B %Hh%M', '%HH%M'], lang=user.lang + '.utf8')" />
                                 <t t-set="date_end" t-value="user.get_time_by_user_lang(shift.date_end, ['%A %d %B %Hh%M', '%HH%M'], lang=user.lang + '.utf8')" />
                                 <div><span t-esc="date_begin and date_begin[0] or ''" /> - <span t-esc="date_end and date_end[1] or ''" /></div>
                                 <div><span t-esc="shift.seats_reserved" /> participants attendus</div>
-                                <div t-attf-style="color: {{ color }};"><strong><span t-esc="shift.seats_available" /> places disponibles</strong></div>
+                                <div><strong><span t-esc="shift.seats_available" /> places disponibles</strong></div>
                             </div>
                         </t>
                     </div>

--- a/intercoop_addons/coop_memberspace/views/website/planning.xml
+++ b/intercoop_addons/coop_memberspace/views/website/planning.xml
@@ -5,8 +5,8 @@
             <t t-set="title">Espace Membre | Planning</t>
             <div class="container">
                 <div class="row">
-                    <h1>Planning Supercoop</h1>
-                    <p>Manque de coopérateurs sur les services à venir : choisir en priorité les créneaux <span style="color: #ee2c2c;">rouges</span>, puis <span style="color: #ffa500;">oranges</span>, puis <span style="color: #ffd700;">jaunes</span>, puis <span style="color: #ffe4c4;">beiges</span>...</p>
+                    <h1>Planning du magasin</h1>
+                    <p>Manque de coopérateurs·trices sur les services à venir : choisir en priorité les créneaux <span style="color: #ee2c2c;">rouges</span>, puis <span style="color: #ffa500;">oranges</span>, puis <span style="color: #ffd700;">jaunes</span>, puis <span style="color: #ffe4c4;">beiges</span>...</p>
                     <div class="row">
                         <t t-if="upcoming_shifts">
                             <t t-set="week_number" t-value="dict(upcoming_shifts[0]._fields['week_number'].selection).get(upcoming_shifts[0].week_number)" />


### PR DESCRIPTION
Ajoute une page */planning* pour afficher le planning des prochains créneaux confirmes. Permet aux coopérateurs·trices de voir les places disponibles selon les critères suivants :

* il reste des places sur un créneau prévu dans moins de 3 jours => rouge
* il reste 75% de place sur un créneau futur => orange
* il reste entre 50% et 75% de place => jaune
* il reste entre 50% et 25% de place => beige

<img width="631" alt="Capture d’écran 2019-08-29 à 15 36 43" src="https://user-images.githubusercontent.com/24719117/63944958-18038380-ca62-11e9-930d-9b269fdde1db.png">
