### PR TITLE
Page planning

### DIFF
--- a/intercoop_addons/coop_memberspace/__openerp__.py
+++ b/intercoop_addons/coop_memberspace/__openerp__.py
@@ -8,7 +8,6 @@
     'name': 'Coop Memberspace',
     'description': """
         Version 0.0.0.2 : ajout de la page planning par Supercoop pour visualiser les prochains services confirmés avec le nombre de places disponibles 
-        ATTENTION : WIP sur la prod de Supercoop, pas encore pushé sur le répertoire github commun !
     """,
     'version': '0.0.0.2',
     'category': 'Custom',

--- a/intercoop_addons/coop_memberspace/__openerp__.py
+++ b/intercoop_addons/coop_memberspace/__openerp__.py
@@ -6,7 +6,11 @@
 
 {
     'name': 'Coop Memberspace',
-    'version': '0.0.0.1',
+    'description': """
+        Version 0.0.0.2 : ajout de la page planning par Supercoop pour visualiser les prochains services confirmés avec le nombre de places disponibles 
+        ATTENTION : WIP sur la prod de Supercoop, pas encore pushé sur le répertoire github commun !
+    """,
+    'version': '0.0.0.2',
     'category': 'Custom',
     'author': 'La Louve',
     'website': 'http://www.lalouve.net',
@@ -45,6 +49,7 @@
         'views/website/statistics.xml',
         'views/website/website_homepage.xml',
         'views/website/website_template.xml',
+        'views/website/planning.xml',
     ],
     'installable': True,
 }

--- a/intercoop_addons/coop_memberspace/__openerp__.py
+++ b/intercoop_addons/coop_memberspace/__openerp__.py
@@ -7,9 +7,10 @@
 {
     'name': 'Coop Memberspace',
     'description': """
+        Version 0.0.0.3 : inscription à un service (volant ou rattrapage) possible depuis la page planning
         Version 0.0.0.2 : ajout de la page planning par Supercoop pour visualiser les prochains services confirmés avec le nombre de places disponibles 
     """,
-    'version': '0.0.0.2',
+    'version': '0.0.0.3',
     'category': 'Custom',
     'author': 'La Louve',
     'website': 'http://www.lalouve.net',

--- a/intercoop_addons/coop_memberspace/controllers/main.py
+++ b/intercoop_addons/coop_memberspace/controllers/main.py
@@ -79,6 +79,7 @@ class Website(openerp.addons.website.controllers.main.Website):
     def page_planning(self, **kwargs):
         user = request.env.user
         upcoming_shifts = request.env['shift.shift'].sudo().search([
+            ('shift_template_id.is_technical', '=', False),
             ('date_begin', '>=', datetime.now().strftime('%Y-%m-%d %H:%M:%S')),
             ('state', '=', 'confirm'),
         ], order="date_begin") or []

--- a/intercoop_addons/coop_memberspace/controllers/main.py
+++ b/intercoop_addons/coop_memberspace/controllers/main.py
@@ -77,6 +77,7 @@ class Website(openerp.addons.website.controllers.main.Website):
 
     @http.route('/planning', type='http', auth='user', website=True)
     def page_planning(self, **kwargs):
+        user = request.env.user
         upcoming_shifts = request.env['shift.shift'].sudo().search([
             ('date_begin', '>=', datetime.now().strftime('%Y-%m-%d %H:%M:%S')),
             ('state', '=', 'confirm'),
@@ -84,7 +85,8 @@ class Website(openerp.addons.website.controllers.main.Website):
         return request.render(
             'coop_memberspace.planning',
             {
-                'user': request.env.user,
+                'user': user,
+                'shift_type': user.partner_id.shift_type,
                 'upcoming_shifts': upcoming_shifts,
             }
         )

--- a/intercoop_addons/coop_memberspace/controllers/main.py
+++ b/intercoop_addons/coop_memberspace/controllers/main.py
@@ -75,6 +75,20 @@ class Website(openerp.addons.website.controllers.main.Website):
             return http.redirect_with_hash(redirect)
         return r
 
+    @http.route('/planning', type='http', auth='user', website=True)
+    def page_planning(self, **kwargs):
+        upcoming_shifts = request.env['shift.shift'].sudo().search([
+            ('date_begin', '>=', datetime.now().strftime('%Y-%m-%d %H:%M:%S')),
+            ('state', '=', 'confirm'),
+        ], order="date_begin") or []
+        return request.render(
+            'coop_memberspace.planning',
+            {
+                'user': request.env.user,
+                'upcoming_shifts': upcoming_shifts,
+            }
+        )
+
     @http.route('/mywork', type='http', auth='user', website=True)
     def page_mywork(self, **kwargs):
         user = request.env.user

--- a/intercoop_addons/coop_memberspace/data/website_menu.xml
+++ b/intercoop_addons/coop_memberspace/data/website_menu.xml
@@ -65,7 +65,7 @@
             <field name="name">Accueil</field>
         </record>
 
-        <delete model="website.menu" search="[('id','=', ref('website.menu_contactus'))]" />
+        <delete model="website.menu" search="[('id','=', ref('website.contactus'))]" />
 
     </data>
 </openerp>

--- a/intercoop_addons/coop_memberspace/static/src/js/programmer_un_service.js
+++ b/intercoop_addons/coop_memberspace/static/src/js/programmer_un_service.js
@@ -1,0 +1,67 @@
+odoo.define('coop_memberspace.programmer_un_service', function (require) {
+    "use strict";
+
+    var snippet_animation = require('web_editor.snippets.animation');
+    var session = require('web.session');
+    var Model = require('web.Model');
+    var ajax = require("web.ajax");
+
+    snippet_animation.registry.programmer_un_service =
+		snippet_animation.Class.extend({
+            selector: '.programmer_un_service',
+            start: function () {
+                var self = this;
+                ajax.jsonRpc("/web/session/get_session_info", "call").then(function (sessiondata) {
+                    self.session = sessiondata;
+                });
+                $('.fa.fa-user-plus').on('click', function() {
+                    let shift_id = $(this).attr('data-shift-id');
+                    self.shift_id = shift_id;
+                    let shift_type = $(this).attr('data-shift-type');
+                    self.shift_type = shift_type;
+                    let time = $('#time-' + shift_id).text();
+                    $('#modal_time').text(time);
+                });
+
+                $('.fa.fa-check').on('click', function(e) {
+                    e.preventDefault();
+                    let btn_check = this;
+                    $(btn_check).attr("disabled", "disabled");
+                    new Model('shift.ticket').call(
+                        'search', [[['shift_id', '=', parseInt(self.shift_id)], ['shift_type', '=', self.shift_type]]])
+                    .then(function(data) {
+                        if (data.length > 0) {
+                            let vals = {
+                                'state': 'draft',
+                                'partner_id': parseInt(self.session.partner_id),
+                                'shift_id': parseInt(self.shift_id),
+                                'shift_ticket_id': parseInt(data[0]),
+                                'related_extension_id': false
+                            }
+                            new Model('shift.registration').call(
+                                'create', [vals])
+                            .then(function(result) {
+                                $('#btn-add-' + self.shift_id).hide();
+                                let no_available_seats = '#avalable-seats-' + self.shift_id;
+                                $(no_available_seats).text(parseInt($(no_available_seats).text()) - 1);
+                                let shift = "#shift-" + self.shift_id;
+                                $(shift).css({'color': 'grey', 'background-color': '#e7e7e7'});
+                                $('#programmer_modal').modal('hide');
+                                $(btn_check).removeAttr("disabled");
+                            })
+                            .fail(function(error, event) {
+                                $('#error_header').text(error.message);
+                                $('#error_body').text(error.data.arguments[0] || '');
+                                $('#programmer_modal').modal('hide');
+                                $('#error_modal').modal('show');
+                                $(btn_check).removeAttr("disabled");
+                            });
+                        }
+                        else {
+                            $(btn_check).removeAttr("disabled");
+                        }
+                    })
+                });
+            }
+        })
+});

--- a/intercoop_addons/coop_memberspace/views/templates.xml
+++ b/intercoop_addons/coop_memberspace/views/templates.xml
@@ -22,6 +22,7 @@
             <script src="/coop_memberspace/static/src/js/style.js" type="text/javascript"/>
             <script src="/coop_memberspace/static/src/js/programmer_un_extra.js" type="text/javascript"/>
             <script src="/coop_memberspace/static/src/js/programmer_une_vacation.js" type="text/javascript"/>
+            <script src="/coop_memberspace/static/src/js/programmer_un_service.js" type="text/javascript"/>
             <script src="/coop_memberspace/static/src/js/my_profile.js" type="text/javascript"/>
             <script src="/coop_memberspace/static/src/js/statistics.js" type="text/javascript"/>
             <script src="/coop_memberspace/static/src/js/exchange_shift.js" type="text/javascript"/>

--- a/intercoop_addons/coop_memberspace/views/website/planning.xml
+++ b/intercoop_addons/coop_memberspace/views/website/planning.xml
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="utf-8"?>
+<openerp><data>
+	<template id="coop_memberspace.planning">
+		<t t-call="website.layout">
+            <t t-set="title">Espace Membre | Planning</t>
+            <div class="container">
+                <div class="row">
+                    <h1>Manque de coopérateurs sur les services à venir</h1>
+                    <p>Page fonctionnelle mais toujours en cours de développement par le cercle informatique, des améliorations (notamment cosmétiques) sont encore prévues :)</p>
+                    <div class="row">
+                        <t t-if="upcoming_shifts">
+                            <t t-set="week_number" t-value="dict(upcoming_shifts[0]._fields['week_number'].selection).get(upcoming_shifts[0].week_number)" />
+                            <t t-set="date" t-value="upcoming_shifts[0].date_without_time" />
+                            <div class="col-md-12"><h3>Semaine <span t-esc="week_number" /></h3></div>
+                            <div class="col-md-12"><h4><span t-esc="date" /></h4></div>
+                        </t>
+                        <t t-if="upcoming_shifts" t-foreach="upcoming_shifts" t-as="shift">
+                            <t t-if="dict(shift._fields['week_number'].selection).get(shift.week_number) != week_number">
+                                <t t-set="week_number" t-value="dict(shift._fields['week_number'].selection).get(shift.week_number)" />
+                                <div class="col-md-12"><h3>Semaine <span t-esc="week_number" /></h3></div>
+                            </t>
+                            <t t-if="shift.date_without_time != date">
+                                <t t-set="date" t-value="shift.date_without_time" />
+                                <div class="col-md-12"><h4><span t-esc="date" /></h4></div>
+                            </t>
+                            <t t-if="shift.seats_available >= shift.seats_reserved" t-set="color" t-value="'red'" />
+                            <t t-if="shift.seats_reserved > shift.seats_available" t-set="color" t-value="'black'" />
+                            <div class="col-md-3" t-attf-style="border: 1px solid {{ color }}; margin: 10px;">
+                                <h5><span t-esc="shift.name" /></h5>
+                                <t t-set="date_begin" t-value="user.get_time_by_user_lang(shift.date_begin, ['%A %d %B %Hh%M', '%HH%M'], lang=user.lang + '.utf8')" />
+                                <t t-set="date_end" t-value="user.get_time_by_user_lang(shift.date_end, ['%A %d %B %Hh%M', '%HH%M'], lang=user.lang + '.utf8')" />
+                                <div><span t-esc="date_begin and date_begin[0] or ''" /> - <span t-esc="date_end and date_end[1] or ''" /></div>
+                                <div><span t-esc="shift.seats_reserved" /> participants attendus</div>
+                                <div t-attf-style="color: {{ color }};"><strong><span t-esc="shift.seats_available" /> places disponibles</strong></div>
+                            </div>
+                        </t>
+                    </div>
+                </div>
+            </div>
+        </t>
+    </template>
+</data></openerp>

--- a/intercoop_addons/coop_memberspace/views/website/planning.xml
+++ b/intercoop_addons/coop_memberspace/views/website/planning.xml
@@ -5,14 +5,14 @@
             <t t-set="title">Espace Membre | Planning</t>
             <div class="container">
                 <div class="row">
-                    <h1>Manque de coopérateurs sur les services à venir</h1>
-                    <p>Page fonctionnelle mais toujours en cours de développement par le cercle informatique, des améliorations (notamment cosmétiques) sont encore prévues :)</p>
+                    <h1>Planning Supercoop</h1>
+                    <p>Manque de coopérateurs sur les services à venir : choisir en priorité les créneaux <span style="color: #ee2c2c;">rouges</span>, puis <span style="color: #ffa500;">oranges</span>, puis <span style="color: #ffd700;">jaunes</span>, puis <span style="color: #ffe4c4;">beiges</span>...</p>
                     <div class="row">
                         <t t-if="upcoming_shifts">
                             <t t-set="week_number" t-value="dict(upcoming_shifts[0]._fields['week_number'].selection).get(upcoming_shifts[0].week_number)" />
                             <t t-set="date" t-value="upcoming_shifts[0].date_without_time" />
                             <div class="col-md-12"><h3>Semaine <span t-esc="week_number" /></h3></div>
-                            <div class="col-md-12"><h4><span t-esc="date" /></h4></div>
+                            <div class="col-md-12"><h4><span t-esc="user.get_time_by_user_lang(upcoming_shifts[0].date_begin, ['%A %d %B %Y'])[0]" /></h4></div>
                         </t>
                         <t t-if="upcoming_shifts" t-foreach="upcoming_shifts" t-as="shift">
                             <t t-if="dict(shift._fields['week_number'].selection).get(shift.week_number) != week_number">
@@ -21,17 +21,32 @@
                             </t>
                             <t t-if="shift.date_without_time != date">
                                 <t t-set="date" t-value="shift.date_without_time" />
-                                <div class="col-md-12"><h4><span t-esc="date" /></h4></div>
+                                <div class="col-md-12"><h4><span t-esc="user.get_time_by_user_lang(shift.date_begin, ['%A %d %B %Y'])[0]" /></h4></div>
                             </t>
-                            <t t-if="shift.seats_available >= shift.seats_reserved" t-set="color" t-value="'red'" />
-                            <t t-if="shift.seats_reserved > shift.seats_available" t-set="color" t-value="'black'" />
-                            <div class="col-md-3" t-attf-style="border: 1px solid {{ color }}; margin: 10px;">
+                            <t t-set="present" t-value="datetime.datetime.now()" />
+                            <t t-set="availability_rate" t-value="float(shift.seats_available) / shift.seats_max" />
+
+                            <t t-set="css_color_style" t-value="''"/>
+                            <t t-if="availability_rate >= 0.25">
+                                <t t-set="css_color_style" t-value="'color: #665b4e; background-color: #ffe4c4'"/>
+                            </t>
+                            <t t-if="availability_rate >= 0.5">
+                                <t t-set="css_color_style" t-value="'color: #665600; background-color: #ffd700'"/>
+                            </t>
+                            <t t-if="availability_rate >= 0.75">
+                                <t t-set="css_color_style" t-value="'color: #664200; background-color: #ffa500;'"/>
+                            </t>
+                            <t t-if="shift.seats_available > 0 and present > (datetime.datetime.strptime(shift.date_begin_tz, '%Y-%m-%d %H:%M:%S') - datetime.timedelta(days=3))">
+                                <t t-set="css_color_style" t-value="'color: #fbd4d4; background-color: #ee2c2c;'"/>
+                            </t>
+
+                            <div t-attf-class="col-md-3" t-attf-style="border: 1px solid; margin: 10px; {{ css_color_style }}">
                                 <h5><span t-esc="shift.name" /></h5>
                                 <t t-set="date_begin" t-value="user.get_time_by_user_lang(shift.date_begin, ['%A %d %B %Hh%M', '%HH%M'], lang=user.lang + '.utf8')" />
                                 <t t-set="date_end" t-value="user.get_time_by_user_lang(shift.date_end, ['%A %d %B %Hh%M', '%HH%M'], lang=user.lang + '.utf8')" />
                                 <div><span t-esc="date_begin and date_begin[0] or ''" /> - <span t-esc="date_end and date_end[1] or ''" /></div>
                                 <div><span t-esc="shift.seats_reserved" /> participants attendus</div>
-                                <div t-attf-style="color: {{ color }};"><strong><span t-esc="shift.seats_available" /> places disponibles</strong></div>
+                                <div><strong><span t-esc="shift.seats_available" /> places disponibles</strong></div>
                             </div>
                         </t>
                     </div>

--- a/intercoop_addons/coop_memberspace/views/website/planning.xml
+++ b/intercoop_addons/coop_memberspace/views/website/planning.xml
@@ -7,7 +7,7 @@
                 <div class="row">
                     <h1>Planning du magasin</h1>
                     <p>Manque de coopérateurs·trices sur les services à venir : choisir en priorité les créneaux <span style="color: #ee2c2c;">rouges</span>, puis <span style="color: #ffa500;">oranges</span>, puis <span style="color: #ffd700;">jaunes</span>, puis <span style="color: #ffe4c4;">beiges</span>...</p>
-                    <div class="row">
+                    <div class="row programmer_un_service">
                         <t t-if="upcoming_shifts">
                             <t t-set="week_number" t-value="dict(upcoming_shifts[0]._fields['week_number'].selection).get(upcoming_shifts[0].week_number)" />
                             <t t-set="date" t-value="upcoming_shifts[0].date_without_time" />
@@ -25,6 +25,7 @@
                             </t>
                             <t t-set="present" t-value="datetime.datetime.now()" />
                             <t t-set="availability_rate" t-value="float(shift.seats_available) / shift.seats_max" />
+                            <t t-set="user_is_registered" t-value="user.partner_id in shift.registration_ids.mapped('partner_id')" />
 
                             <t t-set="css_color_style" t-value="''"/>
                             <t t-if="availability_rate >= 0.25">
@@ -39,16 +40,26 @@
                             <t t-if="shift.seats_available > 0 and present > (datetime.datetime.strptime(shift.date_begin_tz, '%Y-%m-%d %H:%M:%S') - datetime.timedelta(days=3))">
                                 <t t-set="css_color_style" t-value="'color: #fbd4d4; background-color: #ee2c2c;'"/>
                             </t>
+                            <t t-if="user_is_registered">
+                                <t t-set="css_color_style" t-value="'color: grey; background-color: #e7e7e7;'"/>
+                            </t>
 
-                            <div t-attf-class="col-md-3" t-attf-style="border: 1px solid; margin: 10px; {{ css_color_style }}">
+                            <div t-attf-id="shift-{{shift.id}}" t-attf-class="col-md-3" t-attf-style="border: 1px solid; margin: 10px; {{ css_color_style }}">
                                 <h5><span t-esc="shift.name" /></h5>
                                 <t t-set="date_begin" t-value="user.get_time_by_user_lang(shift.date_begin, ['%A %d %B %Hh%M', '%HH%M'], lang=user.lang + '.utf8')" />
                                 <t t-set="date_end" t-value="user.get_time_by_user_lang(shift.date_end, ['%A %d %B %Hh%M', '%HH%M'], lang=user.lang + '.utf8')" />
-                                <div><span t-esc="date_begin and date_begin[0] or ''" /> - <span t-esc="date_end and date_end[1] or ''" /></div>
+                                <div><span t-attf-id="time-{{shift.id}}" t-esc="date_begin and date_begin[0] or ''" /> - <span t-esc="date_end and date_end[1] or ''" /></div>
                                 <div><span t-esc="shift.seats_reserved" /> participants attendus</div>
-                                <div><strong><span t-esc="shift.seats_available" /> places disponibles</strong></div>
+                                <div>
+                                    <strong><span t-attf-id="avalable-seats-{{shift.id}}" t-esc="shift.seats_available" /> places disponibles</strong>
+                                    <t t-if="shift.seats_available > 0 and not user_is_registered">
+                                        <a><span class="fa fa-user-plus" data-toggle="modal" data-target="#programmer_modal" t-attf-id="btn-add-{{shift.id}}" t-att-data-shift-id="shift.id" t-att-data-shift-type="shift_type" /></a>
+                                    </t>
+                                </div>
                             </div>
                         </t>
+                        <t t-call="coop_memberspace.programmer_modal" />
+                        <t t-call="coop_memberspace.modal_error" />
                     </div>
                 </div>
             </div>

--- a/intercoop_addons/coop_memberspace/views/website/planning.xml
+++ b/intercoop_addons/coop_memberspace/views/website/planning.xml
@@ -5,8 +5,8 @@
             <t t-set="title">Espace Membre | Planning</t>
             <div class="container">
                 <div class="row">
-                    <h1>Planning Supercoop</h1>
-                    <p>Manque de coopérateurs sur les services à venir : choisir en priorité les créneaux <span style="color: #ee2c2c;">rouges</span>, puis <span style="color: #ffa500;">oranges</span>, puis <span style="color: #ffd700;">jaunes</span>, puis <span style="color: #ffe4c4;">beiges</span>...</p>
+                    <h1>Planning du magasin</h1>
+                    <p>Manque de coopérateurs·trices sur les services à venir : choisir en priorité les créneaux <span style="color: #ee2c2c;">rouges</span>, puis <span style="color: #ffa500;">oranges</span>, puis <span style="color: #ffd700;">jaunes</span>, puis <span style="color: #ffe4c4;">beiges</span>...</p>
                     <div class="row">
                         <t t-if="upcoming_shifts">
                             <t t-set="week_number" t-value="dict(upcoming_shifts[0]._fields['week_number'].selection).get(upcoming_shifts[0].week_number)" />


### PR DESCRIPTION
Ajoute une page */planning* pour afficher le planning des prochains créneaux confirmes. Permet aux coopérateurs·trices de voir les places disponibles selon les critères suivants :

* il reste des places sur un créneau prévu dans moins de 3 jours => rouge
* il reste 75% de place sur un créneau futur => orange
* il reste entre 50% et 75% de place => jaune
* il reste entre 50% et 25% de place => beige

<img width="631" alt="Capture d’écran 2019-08-29 à 15 36 43" src="https://user-images.githubusercontent.com/24719117/63944958-18038380-ca62-11e9-930d-9b269fdde1db.png">
