### PR TITLE
[FIX] theme_bootswatch: replace protocol-relative urls by https ones

### DIFF
--- a/odoo/addons/theme_bootswatch/static/src/less/amelia/bootswatch.less
+++ b/odoo/addons/theme_bootswatch/static/src/less/amelia/bootswatch.less
@@ -2,7 +2,7 @@
 // Bootswatch
 // -----------------------------------------------------
 
-@import url("//fonts.googleapis.com/css?family=Lobster|Cabin:400,700");
+@import url("https://fonts.googleapis.com/css?family=Lobster|Cabin:400,700");
 
 // Navbar =====================================================================
 

--- a/odoo/addons/theme_bootswatch/static/src/less/cosmo/bootswatch.less
+++ b/odoo/addons/theme_bootswatch/static/src/less/cosmo/bootswatch.less
@@ -2,7 +2,7 @@
 // Bootswatch
 // -----------------------------------------------------
 
-@import url("//fonts.googleapis.com/css?family=Source+Sans+Pro:300,400,700");
+@import url("https://fonts.googleapis.com/css?family=Source+Sans+Pro:300,400,700");
 
 // Navbar =====================================================================
 

--- a/odoo/addons/theme_bootswatch/static/src/less/cyborg/bootswatch.less
+++ b/odoo/addons/theme_bootswatch/static/src/less/cyborg/bootswatch.less
@@ -2,7 +2,7 @@
 // Bootswatch
 // -----------------------------------------------------
 
-@import url("//fonts.googleapis.com/css?family=Roboto:400,700");
+@import url("https://fonts.googleapis.com/css?family=Roboto:400,700");
 
 // Navbar =====================================================================
 

--- a/odoo/addons/theme_bootswatch/static/src/less/flatly/bootswatch.less
+++ b/odoo/addons/theme_bootswatch/static/src/less/flatly/bootswatch.less
@@ -2,7 +2,7 @@
 // Bootswatch
 // -----------------------------------------------------
 
-@import url("//fonts.googleapis.com/css?family=Lato:400,700,400italic");
+@import url("https://fonts.googleapis.com/css?family=Lato:400,700,400italic");
 
 // Navbar =====================================================================
 

--- a/odoo/addons/theme_bootswatch/static/src/less/journal/bootswatch.less
+++ b/odoo/addons/theme_bootswatch/static/src/less/journal/bootswatch.less
@@ -2,7 +2,7 @@
 // Bootswatch
 // -----------------------------------------------------
 
-@import url("//fonts.googleapis.com/css?family=News+Cycle:400,700");
+@import url("https://fonts.googleapis.com/css?family=News+Cycle:400,700");
 
 // Navbar =====================================================================
 

--- a/odoo/addons/theme_bootswatch/static/src/less/readable/bootswatch.less
+++ b/odoo/addons/theme_bootswatch/static/src/less/readable/bootswatch.less
@@ -2,7 +2,7 @@
 // Bootswatch
 // -----------------------------------------------------
 
-@import url("//fonts.googleapis.com/css?family=Raleway:400,700");
+@import url("https://fonts.googleapis.com/css?family=Raleway:400,700");
 
 // Navbar =====================================================================
 

--- a/odoo/addons/theme_bootswatch/static/src/less/simplex/bootswatch.less
+++ b/odoo/addons/theme_bootswatch/static/src/less/simplex/bootswatch.less
@@ -2,7 +2,7 @@
 // Bootswatch
 // -----------------------------------------------------
 
-@import url("//fonts.googleapis.com/css?family=Open+Sans:400,700");
+@import url("https://fonts.googleapis.com/css?family=Open+Sans:400,700");
 
 .btn-shadow(@color) {
   #gradient > .vertical-three-colors(lighten(@color, 3%), @color, 6%, darken(@color, 3%));

--- a/odoo/addons/theme_bootswatch/static/src/less/spacelab/bootswatch.less
+++ b/odoo/addons/theme_bootswatch/static/src/less/spacelab/bootswatch.less
@@ -2,7 +2,7 @@
 // Bootswatch
 // -----------------------------------------------------
 
-@import url("//fonts.googleapis.com/css?family=Open+Sans:400italic,700italic,400,700");
+@import url("https://fonts.googleapis.com/css?family=Open+Sans:400italic,700italic,400,700");
 
 .btn-shadow(@color) {
   #gradient > .vertical-three-colors(lighten(@color, 15%), @color, 50%, darken(@color, 4%));

--- a/odoo/addons/theme_bootswatch/static/src/less/united/bootswatch.less
+++ b/odoo/addons/theme_bootswatch/static/src/less/united/bootswatch.less
@@ -2,7 +2,7 @@
 // Bootswatch
 // -----------------------------------------------------
 
-@import url("//fonts.googleapis.com/css?family=Ubuntu");
+@import url("https://fonts.googleapis.com/css?family=Ubuntu");
 
 // Navbar =====================================================================
 


### PR DESCRIPTION
- to support nodejs >= 10.x (used by lessc)
- backward compatible