### PR TITLE
[coop_badge_reader addon] Preserve aspect-ratio of badge image

### DIFF
--- a/intercoop_addons/coop_badge_reader/static/www/css/style.css
+++ b/intercoop_addons/coop_badge_reader/static/www/css/style.css
@@ -45,6 +45,7 @@ div.jumbotron{
 .img-badge-partner-form{
     width: 280px;
     height: 280px;
+    object-fit: contain;
 }
 
 .img-partner-list{


### PR DESCRIPTION
Hi :-)

I'm David, member of Superquinquin in Lille
My picture is all spread in the coop_badge_reader screen
Based on quick tests, it seems like `object-fit: contain;` fixes the problem

I'm new to the project, so i'm not familiar with the contribution process

I'm happy to improve this PR with guidance if it doesn't comply with current standards